### PR TITLE
Mark Natives As Optional

### DIFF
--- a/scripting/include/steampawn.inc
+++ b/scripting/include/steampawn.inc
@@ -40,3 +40,12 @@ public SharedPlugin __pl_steampawn = {
 	required = 0,
 #endif
 };
+
+#if !defined REQUIRE_PLUGIN
+public void __pl_steampawn_SetNTVOptional()
+{
+	MarkNativeAsOptional("SteamPawn_IsSteamConnected");
+	MarkNativeAsOptional("SteamPawn_GetSDRFakeIP");
+	MarkNativeAsOptional("SteamPawn_GetSDRFakePort");
+}
+#endif


### PR DESCRIPTION
This PR adds the missing *MarkNativeAsOptional*. Required for other plugins to be able to mark this as an optional requirement.