### PR TITLE
x64 Support (Linux only)

### DIFF
--- a/gamedata/steampawn.txt
+++ b/gamedata/steampawn.txt
@@ -130,13 +130,6 @@
 				"windows"	"11"
 				"windows64"	"11"
 			}
-			"Arch" // Used for arch detection
-			{
-				"linux"		"0"
-				"windows"	"0"
-				"linux64"	"1"
-				"windows64"	"1"
-			}
 		}
 		"Keys"
 		{

--- a/gamedata/steampawn.txt
+++ b/gamedata/steampawn.txt
@@ -23,11 +23,6 @@
 					"signature"	"CSteam3Server::OnFakeIPResults()"
 					"read"		"37"
 				}
-				"windows64"
-				{
-					"signature"	"CSteam3Server::OnFakeIPResults()"
-					"read"		"37"
-				}
 			}
 			"g_arFakePorts"
 			{
@@ -44,11 +39,6 @@
 					"signature"	"CSteam3Server::OnFakeIPResults()"
 					"read"		"135"
 				}
-				"windows64"
-				{
-					"signature"	"CSteam3Server::OnFakeIPResults()"
-					"read"		"147"
-				}
 			}
 			"s_Steam3Server"
 			{
@@ -56,12 +46,6 @@
 				{
 					"signature"	"sv_setsteamaccount_f()"
 					"read"		"5"
-					"offset"	"-4"
-				}
-				"windows64"
-				{
-					"signature"	"sv_setsteamaccount_f()"
-					"read"		"12"
 					"offset"	"-4"
 				}
 			}

--- a/gamedata/steampawn.txt
+++ b/gamedata/steampawn.txt
@@ -14,7 +14,16 @@
 				{
 					"signature"	"g_nFakeIP"
 				}
+				"linux64"
+				{
+					"signature"	"g_nFakeIP"
+				}
 				"windows"
+				{
+					"signature"	"CSteam3Server::OnFakeIPResults()"
+					"read"		"37"
+				}
+				"windows64"
 				{
 					"signature"	"CSteam3Server::OnFakeIPResults()"
 					"read"		"37"
@@ -26,10 +35,19 @@
 				{
 					"signature"	"g_arFakePorts"
 				}
+				"linux64"
+				{
+					"signature"	"g_arFakePorts"
+				}
 				"windows"
 				{
 					"signature"	"CSteam3Server::OnFakeIPResults()"
 					"read"		"135"
+				}
+				"windows64"
+				{
+					"signature"	"CSteam3Server::OnFakeIPResults()"
+					"read"		"147"
 				}
 			}
 			"s_Steam3Server"
@@ -38,6 +56,12 @@
 				{
 					"signature"	"sv_setsteamaccount_f()"
 					"read"		"5"
+					"offset"	"-4"
+				}
+				"windows64"
+				{
+					"signature"	"sv_setsteamaccount_f()"
+					"read"		"12"
 					"offset"	"-4"
 				}
 			}
@@ -58,28 +82,34 @@
 			{
 				"library"	"engine"
 				"linux"		"@_Z12Steam3Serverv"
+				"linux64"	"@_Z12Steam3Serverv"
 			}
 			"CSteam3Server::OnFakeIPResults()"
 			{
 				// contains unique string "FakeIP allocation succeeded: %s"
 				"library"	"engine"
 				"windows"	"\x55\x8B\xEC\x8B\x4D\x08\x83\xEC\x1C"
+				"windows64"	"\x40\x57\x48\x83\xEC\x40\x48\x8B\xFA"
 			}
 			"sv_setsteamaccount_f()"
 			{
+				// contains unique string "Usage: sv_setsteamaccount <login_token>\n"
 				"library"	"engine"
 				"windows"	"\x55\x8B\xEC\x8B\x0D\x2A\x2A\x2A\x2A\x85\xC9\x74\x2A\x8B\x01\x8B\x40\x20"
+				"windows64"	"\x40\x53\x48\x83\xEC\x20\x48\x8B\xD9\x48\x8B\x0D\x2A\x2A\x2A\x2A\x48\x85\xC9\x74\x2A\x48\x8B\x01\xFF\x50\x2A\x84\xC0"
 			}
 			
 			"g_nFakeIP"
 			{
 				"library"	"engine"
 				"linux"		"@g_nFakeIP"
+				"linux64"	"@g_nFakeIP"
 			}
 			"g_arFakePorts"
 			{
 				"library"	"engine"
 				"linux"		"@g_arFakePorts"
+				"linux64"	"@g_arFakePorts"
 			}
 		}
 		"Offsets"
@@ -88,13 +118,24 @@
 			{
 				// vcalled in status(CCommand const&)
 				"linux"		"8"
+				"linux64"	"8"
 				"windows"	"8"
+				"windows64"	"8"
 			}
 			"ISteamGameServer::WasRestartRequested()"
 			{
 				// vcalled early in CBaseServer::CheckMasterServerRequestRestart()
 				"linux"		"11"
+				"linux64"	"11"
 				"windows"	"11"
+				"windows64"	"11"
+			}
+			"Arch" // Used for arch detection
+			{
+				"linux"		"0"
+				"windows"	"0"
+				"linux64"	"1"
+				"windows64"	"1"
 			}
 		}
 		"Keys"

--- a/scripting/steampawn.sp
+++ b/scripting/steampawn.sp
@@ -3,7 +3,6 @@
  */
 #pragma semicolon 1
 #include <sourcemod>
-#include <virtual_address>
 #include <sdktools>
 // Mark dhooks as optional since it's not available for Linux x64 yet
 #undef REQUIRE_EXTENSIONS
@@ -68,7 +67,7 @@ public void OnPluginStart() {
 
 	StartPrepSDKCall(SDKCall_Static);
 	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Signature, "Steam3Server()");
-	PrepSDKCall_SetReturnInfo(SDKType_VirtualAddress, SDKPass_Plain);
+	PrepSDKCall_SetReturnInfo(SDKType_Address, SDKPass_Plain);
 	g_SDKCallGetSteam3Server = EndPrepSDKCall();
 	if (!g_SDKCallGetSteam3Server) {
 		g_pSteam3Server = hGameConf.GetAddress("s_Steam3Server");
@@ -76,10 +75,10 @@ public void OnPluginStart() {
 			SetFailState("Failed to get address to Steam3Server instance");
 		}
 	} else {
-		g_pSteam3Server = SDKCall(g_SDKCallGetSteam3Server);
+		SDKCall(g_SDKCallGetSteam3Server, g_pSteam3Server);
 	}
 	
-	StartPrepSDKCall(SDKCall_VirtualAddress);
+	StartPrepSDKCall(SDKCall_Raw);
 	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Virtual, "ISteamGameServer::BLoggedOn()");
 	PrepSDKCall_SetReturnInfo(SDKType_Bool, SDKPass_Plain);
 	g_SDKCallIsLoggedOn = EndPrepSDKCall();
@@ -135,7 +134,7 @@ int Native_GetSDRFakePort(Handle plugin, int argc) {
 }
 
 Address GetSteamGameServer() {
-	return DereferencePointer(g_pSteam3Server + view_as<Address>(0x04));
+	return DereferencePointer(g_pSteam3Server + 0x04);
 }
 
 int GetSDRFakeIP() {
@@ -149,5 +148,5 @@ int GetSDRFakePort(int num) {
 	if (!g_parFakePorts || num < 0 || num >= g_nFakePorts) {
 		return 0;
 	}
-	return LoadFromAddress(g_parFakePorts + view_as<Address>((num * 0x2)), NumberType_Int16);
+	return LoadFromAddress(g_parFakePorts + (num * 0x2), NumberType_Int16);
 }

--- a/scripting/steampawn.sp
+++ b/scripting/steampawn.sp
@@ -3,7 +3,7 @@
  */
 #pragma semicolon 1
 #include <sourcemod>
-
+#include <virtual_address>
 #include <sdktools>
 // Mark dhooks as optional since it's not available for Linux x64 yet
 #undef REQUIRE_EXTENSIONS
@@ -13,12 +13,7 @@
 #include <stocksoup/convars>
 #include <stocksoup/memory>
 
-#tryinclude <virtual_address>
-
 #pragma newdecls required
-
-#define ARCH_X86 0
-#define ARCH_X64 1
 
 #define PLUGIN_VERSION "1.2.0"
 public Plugin myinfo = {
@@ -71,33 +66,12 @@ public void OnPluginStart() {
 		LogMessage("Dhooks is not available, SteamPawn_OnRestartRequested forward won't be called.");
 	}
 
-
-
-#if !defined _virtual_address_included
-	// No virtual address (IE: compiled against SM 1.12)
-
-	int arch = hGameConf.GetOffset("Arch");
-
-	if (arch == -1) {
-		SetFailState("Failed to determine the server's architecture. "
-				... "SteamPawn's gamedata file may be outdated!");
-	}
-
-	if (arch == ARCH_X64) {
-		SetFailState("Virtual Addresses (SM 1.13+) is required for x64!");
-	}
-#endif
-
 	StartPrepSDKCall(SDKCall_Static);
 	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Signature, "Steam3Server()");
-#if defined _virtual_address_included
 	PrepSDKCall_SetReturnInfo(SDKType_VirtualAddress, SDKPass_Plain);
-#else
-	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
-#endif
 	g_SDKCallGetSteam3Server = EndPrepSDKCall();
 	if (!g_SDKCallGetSteam3Server) {
-		g_pSteam3Server = GameConfGetAddress(hGameConf, "s_Steam3Server");
+		g_pSteam3Server = hGameConf.GetAddress("s_Steam3Server");
 		if (!g_pSteam3Server) {
 			SetFailState("Failed to get address to Steam3Server instance");
 		}
@@ -105,11 +79,6 @@ public void OnPluginStart() {
 		g_pSteam3Server = SDKCall(g_SDKCallGetSteam3Server);
 	}
 	
-#if defined _virtual_address_included
-	StartPrepSDKCall(SDKCall_VirtualAddress);
-#else
-	StartPrepSDKCall(SDKCall_Raw);
-#endif
 	StartPrepSDKCall(SDKCall_VirtualAddress);
 	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Virtual, "ISteamGameServer::BLoggedOn()");
 	PrepSDKCall_SetReturnInfo(SDKType_Bool, SDKPass_Plain);
@@ -118,11 +87,11 @@ public void OnPluginStart() {
 		SetFailState("Failed to initialize SDKCall to ISteamGameServer::BLoggedOn()");
 	}
 	
-	g_pnFakeIP = GameConfGetAddress(hGameConf, "g_nFakeIP");
-	g_parFakePorts = GameConfGetAddress(hGameConf, "g_arFakePorts");
+	g_pnFakeIP = hGameConf.GetAddress("g_nFakeIP");
+	g_parFakePorts = hGameConf.GetAddress("g_arFakePorts");
 	
 	char strNumFakePorts[4];
-	GameConfGetKeyValue(hGameConf, "NumFakePorts", strNumFakePorts, sizeof(strNumFakePorts));
+	hGameConf.GetKeyValue("NumFakePorts", strNumFakePorts, sizeof(strNumFakePorts));
 	g_nFakePorts = StringToInt(strNumFakePorts);
 	
 	delete hGameConf;

--- a/scripting/steampawn.sp
+++ b/scripting/steampawn.sp
@@ -5,12 +5,20 @@
 #include <sourcemod>
 
 #include <sdktools>
+// Mark dhooks as optional since it's not available for Linux x64 yet
+#undef REQUIRE_EXTENSIONS
 #include <dhooks>
+#define REQUIRE_EXTENSIONS
 
 #include <stocksoup/convars>
 #include <stocksoup/memory>
 
+#tryinclude <virtual_address>
+
 #pragma newdecls required
+
+#define ARCH_X86 0
+#define ARCH_X64 1
 
 #define PLUGIN_VERSION "1.2.0"
 public Plugin myinfo = {
@@ -44,18 +52,62 @@ public APLRes AskPluginLoad2(Handle hPlugin, bool late, char[] error, int maxlen
 }
 
 public void OnPluginStart() {
-	Handle hGameConf = LoadGameConfigFile("steampawn");
+	GameData hGameConf = new GameData("steampawn");
 	if (!hGameConf) {
 		SetFailState("Failed to load gamedata (steampawn).");
 	}
 	
-	g_DHookRestartRequested = DHookCreateFromConf(hGameConf,
-			"ISteamGameServer::WasRestartRequested()");
-	if (!g_DHookRestartRequested) {
-		SetFailState("Failed to create virtual hook for "
-				... "ISteamGameServer::WasRestartRequested()");
+	bool isDhooksAvailable = LibraryExists("dhooks");
+
+	if (isDhooksAvailable) {
+		g_DHookRestartRequested = DHookCreateFromConf(hGameConf,
+				"ISteamGameServer::WasRestartRequested()");
+		if (!g_DHookRestartRequested) {
+			SetFailState("Failed to create virtual hook for "
+					... "ISteamGameServer::WasRestartRequested()");
+		}
+	}
+	else {
+		LogMessage("Dhooks is not available, SteamPawn_OnRestartRequested forward won't be called.");
+	}
+
+	int arch = hGameConf.GetOffset("Arch");
+
+	if (arch == -1) {
+		SetFailState("Failed to determine the server's architecture. "
+				... "SteamPawn's gamedata file may be outdated!");
+	}
+
+#if defined _virtual_address_included
+
+	StartPrepSDKCall(SDKCall_Static);
+	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Signature, "Steam3Server()");
+	PrepSDKCall_SetReturnInfo(SDKType_VirtualAddress, SDKPass_Plain);
+	g_SDKCallGetSteam3Server = EndPrepSDKCall();
+	if (!g_SDKCallGetSteam3Server) {
+		g_pSteam3Server = GameConfGetAddress(hGameConf, "s_Steam3Server");
+		if (!g_pSteam3Server) {
+			SetFailState("Failed to get address to Steam3Server instance");
+		}
+	} else {
+		g_pSteam3Server = SDKCall(g_SDKCallGetSteam3Server);
 	}
 	
+	StartPrepSDKCall(SDKCall_VirtualAddress);
+	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Virtual, "ISteamGameServer::BLoggedOn()");
+	PrepSDKCall_SetReturnInfo(SDKType_Bool, SDKPass_Plain);
+	g_SDKCallIsLoggedOn = EndPrepSDKCall();
+	if (!g_SDKCallIsLoggedOn) {
+		SetFailState("Failed to initialize SDKCall to ISteamGameServer::BLoggedOn()");
+	}
+
+#else
+	// No virtual address (IE: compiled against SM 1.12)
+
+	if (arch == ARCH_X64) {
+		SetFailState("Virtual Addresses (SM 1.13+) is required for x64!");
+	}
+
 	StartPrepSDKCall(SDKCall_Static);
 	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Signature, "Steam3Server()");
 	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
@@ -76,6 +128,8 @@ public void OnPluginStart() {
 	if (!g_SDKCallIsLoggedOn) {
 		SetFailState("Failed to initialize SDKCall to ISteamGameServer::BLoggedOn()");
 	}
+
+#endif
 	
 	g_pnFakeIP = GameConfGetAddress(hGameConf, "g_nFakeIP");
 	g_parFakePorts = GameConfGetAddress(hGameConf, "g_arFakePorts");
@@ -86,8 +140,10 @@ public void OnPluginStart() {
 	
 	delete hGameConf;
 	
-	Address pSteamGameServer = GetSteamGameServer();
-	DHookRaw(g_DHookRestartRequested, true, pSteamGameServer, .callback = OnRestartRequested);
+	if (g_DHookRestartRequested != null) {
+		Address pSteamGameServer = GetSteamGameServer();
+		DHookRaw(g_DHookRestartRequested, true, pSteamGameServer, .callback = OnRestartRequested);
+	}
 	
 	g_FwdRestartRequested = CreateGlobalForward("SteamPawn_OnRestartRequested", ET_Ignore);
 	
@@ -100,6 +156,8 @@ MRESReturn OnRestartRequested(Address pSteamGameServer, Handle hReturn) {
 		Call_StartForward(g_FwdRestartRequested);
 		Call_Finish();
 	}
+
+	return MRES_Ignored;
 }
 
 int Native_IsSteamConnected(Handle plugin, int argc) {
@@ -135,5 +193,5 @@ int GetSDRFakePort(int num) {
 	if (!g_parFakePorts || num < 0 || num >= g_nFakePorts) {
 		return 0;
 	}
-	return LoadFromAddress(g_parFakePorts + (num * 0x2), NumberType_Int16);
+	return LoadFromAddress(g_parFakePorts + view_as<Address>((num * 0x2)), NumberType_Int16);
 }

--- a/scripting/steampawn.sp
+++ b/scripting/steampawn.sp
@@ -71,6 +71,11 @@ public void OnPluginStart() {
 		LogMessage("Dhooks is not available, SteamPawn_OnRestartRequested forward won't be called.");
 	}
 
+
+
+#if !defined _virtual_address_included
+	// No virtual address (IE: compiled against SM 1.12)
+
 	int arch = hGameConf.GetOffset("Arch");
 
 	if (arch == -1) {
@@ -78,11 +83,18 @@ public void OnPluginStart() {
 				... "SteamPawn's gamedata file may be outdated!");
 	}
 
-#if defined _virtual_address_included
+	if (arch == ARCH_X64) {
+		SetFailState("Virtual Addresses (SM 1.13+) is required for x64!");
+	}
+#endif
 
 	StartPrepSDKCall(SDKCall_Static);
 	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Signature, "Steam3Server()");
+#if defined _virtual_address_included
 	PrepSDKCall_SetReturnInfo(SDKType_VirtualAddress, SDKPass_Plain);
+#else
+	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
+#endif
 	g_SDKCallGetSteam3Server = EndPrepSDKCall();
 	if (!g_SDKCallGetSteam3Server) {
 		g_pSteam3Server = GameConfGetAddress(hGameConf, "s_Steam3Server");
@@ -93,6 +105,11 @@ public void OnPluginStart() {
 		g_pSteam3Server = SDKCall(g_SDKCallGetSteam3Server);
 	}
 	
+#if defined _virtual_address_included
+	StartPrepSDKCall(SDKCall_VirtualAddress);
+#else
+	StartPrepSDKCall(SDKCall_Raw);
+#endif
 	StartPrepSDKCall(SDKCall_VirtualAddress);
 	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Virtual, "ISteamGameServer::BLoggedOn()");
 	PrepSDKCall_SetReturnInfo(SDKType_Bool, SDKPass_Plain);
@@ -100,36 +117,6 @@ public void OnPluginStart() {
 	if (!g_SDKCallIsLoggedOn) {
 		SetFailState("Failed to initialize SDKCall to ISteamGameServer::BLoggedOn()");
 	}
-
-#else
-	// No virtual address (IE: compiled against SM 1.12)
-
-	if (arch == ARCH_X64) {
-		SetFailState("Virtual Addresses (SM 1.13+) is required for x64!");
-	}
-
-	StartPrepSDKCall(SDKCall_Static);
-	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Signature, "Steam3Server()");
-	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
-	g_SDKCallGetSteam3Server = EndPrepSDKCall();
-	if (!g_SDKCallGetSteam3Server) {
-		g_pSteam3Server = GameConfGetAddress(hGameConf, "s_Steam3Server");
-		if (!g_pSteam3Server) {
-			SetFailState("Failed to get address to Steam3Server instance");
-		}
-	} else {
-		g_pSteam3Server = SDKCall(g_SDKCallGetSteam3Server);
-	}
-	
-	StartPrepSDKCall(SDKCall_Raw);
-	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Virtual, "ISteamGameServer::BLoggedOn()");
-	PrepSDKCall_SetReturnInfo(SDKType_Bool, SDKPass_Plain);
-	g_SDKCallIsLoggedOn = EndPrepSDKCall();
-	if (!g_SDKCallIsLoggedOn) {
-		SetFailState("Failed to initialize SDKCall to ISteamGameServer::BLoggedOn()");
-	}
-
-#endif
 	
 	g_pnFakeIP = GameConfGetAddress(hGameConf, "g_nFakeIP");
 	g_parFakePorts = GameConfGetAddress(hGameConf, "g_arFakePorts");

--- a/scripting/steampawn.sp
+++ b/scripting/steampawn.sp
@@ -10,7 +10,6 @@
 #define REQUIRE_EXTENSIONS
 
 #include <stocksoup/convars>
-#include <stocksoup/memory>
 
 #pragma newdecls required
 
@@ -134,7 +133,7 @@ int Native_GetSDRFakePort(Handle plugin, int argc) {
 }
 
 Address GetSteamGameServer() {
-	return DereferencePointer(g_pSteam3Server + 0x04);
+	return LoadAddressFromAddress(g_pSteam3Server + 0x04);
 }
 
 int GetSDRFakeIP() {


### PR DESCRIPTION
Adds limited x64 support to SteamPawn.
Dhooks was marked as an optional dependency since it doesn't exists for Linux x64.
The plugin must be compiled with SM 1.13 and the server must also be running SM 1.13 for it to work on x64 as it depends on virtual addresses.
Right now the SDR fake IP natives work on Linux, Windows is broken because I can't figure out the gamedata for it (the `Address` section). It's failing to get an address to Steam3Server on Windows x64.
Tested on TF2.